### PR TITLE
wip: Split fuzz.rs into individual fuzz targets with cargo-fuzz

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,11 @@ path = "fuzz_targets/pop_front.rs"
 [[bin]]
 name = "pop_back"
 path = "fuzz_targets/pop_back.rs"
+
+[[bin]]
+name = "subtendril"
+path = "fuzz_targets/subtendril.rs"
+
+[[bin]]
+name = "try_push_char"
+path = "fuzz_targets/try_push_char.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+
+[package]
+name = "tendril-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.tendril]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[dependencies]
+rand = "0.4"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "string_bytes_eq_tendril"
+path = "fuzz_targets/string_bytes_eq_tendril.rs"
+
+[[bin]]
+name = "pop_front"
+path = "fuzz_targets/pop_front.rs"
+
+[[bin]]
+name = "pop_back"
+path = "fuzz_targets/pop_back.rs"

--- a/fuzz/fuzz_targets/pop_back.rs
+++ b/fuzz/fuzz_targets/pop_back.rs
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test pop_front
+    let mut rng = rand::thread_rng();
+    let new_len = random_boundary(&mut rng, &buf_string);
+    let n = buf_string.len() - new_len;
+    buf_string.truncate(new_len);
+    buf_tendril.pop_back(n as u32);
+    assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});
+
+fn random_boundary<R: Rng>(rng: &mut R, text: &str) -> usize {
+    loop {
+        let i = Range::new(0, text.len() + 1).ind_sample(rng);
+        if text.is_char_boundary(i) {
+            return i;
+        }
+    }
+}

--- a/fuzz/fuzz_targets/pop_front.rs
+++ b/fuzz/fuzz_targets/pop_front.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use] extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test pop_front
+    let mut rng = rand::thread_rng();
+    let n = random_boundary(&mut rng, &buf_string);
+    buf_tendril.pop_front(n as u32);
+    buf_string = buf_string[n..].to_owned();
+    assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});
+
+fn random_boundary<R: Rng>(rng: &mut R, text: &str) -> usize {
+    loop {
+        let i = Range::new(0, text.len()+1).ind_sample(rng);
+        if text.is_char_boundary(i) {
+            return i;
+        }
+    }
+}

--- a/fuzz/fuzz_targets/string_bytes_eq_tendril.rs
+++ b/fuzz/fuzz_targets/string_bytes_eq_tendril.rs
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+use tendril::StrTendril;
+use std::convert::TryInto;
+
+fuzz_target!(|data: &[u8]| {
+    let capacity = data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+        buf_string.push_str(&str);
+        buf_tendril.push_slice(&str);
+        assert_eq!(&*buf_string, &*buf_tendril);
+    }
+});

--- a/fuzz/fuzz_targets/subtendril.rs
+++ b/fuzz/fuzz_targets/subtendril.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+use rand::distributions::{IndependentSample, Range};
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test subtendril
+    let mut rng = rand::thread_rng();
+    let (start, end) = random_slice(&mut rng, &buf_string);
+    buf_string = buf_string[start..end].to_owned();
+    buf_tendril = buf_tendril.subtendril(start as u32, (end - start) as u32);
+    assert_eq!(&*buf_string, &*buf_tendril);
+
+  }
+});
+
+fn random_slice<R: Rng>(rng: &mut R, text: &str) -> (usize, usize) {
+    loop {
+        let start = Range::new(0, text.len() + 1).ind_sample(rng);
+        let end = Range::new(start, text.len() + 1).ind_sample(rng);
+        if !text.is_char_boundary(start) {
+            continue;
+        }
+        if end < text.len() && !text.is_char_boundary(end) {
+            continue;
+        }
+        return (start, end);
+    }
+}

--- a/fuzz/fuzz_targets/try_push_char.rs
+++ b/fuzz/fuzz_targets/try_push_char.rs
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A simple fuzz tester for the library.
+#![no_main]
+#![deny(warnings)]
+#[macro_use]
+extern crate libfuzzer_sys;
+
+extern crate tendril;
+extern crate rand;
+
+use rand::Rng;
+use tendril::StrTendril;
+use std::convert::TryInto;
+
+
+fuzz_target!(|data: &[u8]| {
+    // prelude
+    let capacity= data.len();
+    let mut buf_string = String::with_capacity(capacity as usize);
+    let mut buf_tendril = StrTendril::with_capacity(capacity.try_into().unwrap());
+    if let Ok(str) = std::str::from_utf8(&data) {
+    buf_string.push_str(&str);
+    buf_tendril.push_slice(&str);
+
+    // test try_push_char
+    let mut rng = rand::thread_rng();
+    let c = rng.gen();
+    buf_string.push(c);
+    assert!(buf_tendril.try_push_char(c).is_ok());
+    assert_eq!(&*buf_string, &*buf_tendril);
+  }
+});


### PR DESCRIPTION
I've ommitted the test for `tendril.clear()` as I fail to understand the risk associated with its implementation.

I'm also ommitting this block, as I'm failing to understand its utility:
```rust
            32...47 => {
                let lenstr = format!("[length = {}]", buf_tendril.len());
                buf_string.push_str(&lenstr);
                buf_tendril.push_slice(&lenstr);
                assert_eq!(&*buf_string, &*buf_tendril);
            }
``` 

The "[length = ..]" thing does not seem to cause any different behavior. There is no syntax within tendrils that I could find.


NB: As a follow-up I would like to format the whole crate with rustfmt, as it would make it tremendously easier to develop code while rustfmt is running on the whole repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/tendril/38)
<!-- Reviewable:end -->
