### PR TITLE
Update 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/servo/tendril"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 description = "Compact buffer/string type for zero-copy parsing"
+edition = "2018"
 
 [dependencies]
 encoding = {version = "0.2", optional = true}

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -6,8 +6,7 @@
 
 use std::borrow::ToOwned;
 use std::collections::hash_map::{Entry, HashMap};
-
-use tendril::StrTendril;
+use crate::StrTendril;
 
 fn index_words_string(input: &String) -> HashMap<char, Vec<String>> {
     let mut index = HashMap::new();
@@ -90,45 +89,45 @@ mod index_words {
                 fn index_words_string(b: &mut ::test::Bencher) {
                     let mut s = String::new();
                     while s.len() < SMALL_SIZE {
-                        s.push_str(::tendril::bench::$txt);
+                        s.push_str(crate::tendril::bench::$txt);
                     }
-                    b.iter(|| ::tendril::bench::index_words_string(&s));
+                    b.iter(|| crate::tendril::bench::index_words_string(&s));
                 }
 
                 #[bench]
                 fn index_words_tendril(b: &mut ::test::Bencher) {
-                    let mut t = ::tendril::StrTendril::new();
+                    let mut t = crate::tendril::StrTendril::new();
                     while t.len() < SMALL_SIZE {
-                        t.push_slice(::tendril::bench::$txt);
+                        t.push_slice(crate::tendril::bench::$txt);
                     }
-                    b.iter(|| ::tendril::bench::index_words_tendril(&t));
+                    b.iter(|| crate::tendril::bench::index_words_tendril(&t));
                 }
 
                 #[bench]
                 fn index_words_big_string(b: &mut ::test::Bencher) {
                     let mut s = String::new();
                     while s.len() < LARGE_SIZE {
-                        s.push_str(::tendril::bench::$txt);
+                        s.push_str(crate::tendril::bench::$txt);
                     }
-                    b.iter(|| ::tendril::bench::index_words_string(&s));
+                    b.iter(|| crate::tendril::bench::index_words_string(&s));
                 }
 
                 #[bench]
                 fn index_words_big_tendril(b: &mut ::test::Bencher) {
-                    let mut t = ::tendril::StrTendril::new();
+                    let mut t = crate::tendril::StrTendril::new();
                     while t.len() < LARGE_SIZE {
-                        t.push_slice(::tendril::bench::$txt);
+                        t.push_slice(crate::tendril::bench::$txt);
                     }
-                    b.iter(|| ::tendril::bench::index_words_tendril(&t));
+                    b.iter(|| crate::tendril::bench::index_words_tendril(&t));
                 }
 
                 #[test]
                 fn correctness() {
                     use std::borrow::ToOwned;
-                    use tendril::bench::{index_words_string, index_words_tendril};
-                    use tendril::SliceExt;
+                    use crate::tendril::bench::{index_words_string, index_words_tendril};
+                    use crate::tendril::SliceExt;
 
-                    let txt = ::tendril::bench::$txt;
+                    let txt = crate::tendril::bench::$txt;
                     let input_string = txt.to_owned();
                     let count_s = index_words_string(&input_string);
                     let mut keys: Vec<char> = count_s.keys().cloned().collect();

--- a/src/buf32.rs
+++ b/src/buf32.rs
@@ -8,7 +8,7 @@
 
 use std::{mem, ptr, slice, u32};
 
-use OFLOW;
+use crate::OFLOW;
 
 pub const MIN_CAP: u32 = 16;
 

--- a/src/buf32.rs
+++ b/src/buf32.rs
@@ -6,7 +6,7 @@
 
 //! Provides an unsafe owned buffer type, used in implementing `Tendril`.
 
-use std::{mem, ptr, slice, u32};
+use std::{mem, ptr, slice};
 
 use crate::OFLOW;
 
@@ -44,9 +44,9 @@ impl<H> Buf32<H> {
         ptr::write(ptr, h);
 
         Buf32 {
-            ptr: ptr,
+            ptr,
             len: 0,
-            cap: cap,
+            cap,
         }
     }
 
@@ -61,7 +61,7 @@ impl<H> Buf32<H> {
 
     #[inline(always)]
     pub unsafe fn data_ptr(&self) -> *mut u8 {
-        (self.ptr as *mut u8).offset(mem::size_of::<H>() as isize)
+        (self.ptr as *mut u8).add(size_of::<H>())
     }
 
     #[inline(always)]

--- a/src/buf32.rs
+++ b/src/buf32.rs
@@ -7,12 +7,13 @@
 //! Provides an unsafe owned buffer type, used in implementing `Tendril`.
 
 use std::{mem, ptr, slice};
-
+use std::mem::size_of;
+use std::vec::Vec;
 use crate::OFLOW;
 
 pub const MIN_CAP: u32 = 16;
 
-pub const MAX_LEN: usize = u32::MAX as usize;
+pub const MAX_LEN: usize = u32::max_value() as usize;
 
 /// A buffer points to a header of type `H`, which is followed by `MIN_CAP` or more
 /// bytes of storage.
@@ -111,7 +112,7 @@ mod test {
             assert_eq!(b"Hello", b.data());
 
             b.grow(1337);
-            assert!(b.cap >= 1337);
+            assert_eq!(b.cap >= 1337, true);
             assert_eq!(b"Hello", b.data());
 
             b.destroy();

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -22,7 +22,7 @@
 use std::default::Default;
 use std::{char, mem, str};
 
-use futf::{self, Codepoint, Meaning};
+use crate::futf::{self, Codepoint, Meaning};
 
 /// Implementation details.
 ///

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -91,7 +91,8 @@ pub mod imp {
 /// It's used with a phantom type parameter of `Tendril`.
 /// 
 /// # Safety
-/// Wrong casting of bytes to str may cause undefined behavior.
+/// 
+/// Format must maintain internal invariants.
 pub unsafe trait Format {
     /// Check whether the buffer is valid for this format.
     fn validate(buf: &[u8]) -> bool;
@@ -143,7 +144,8 @@ pub unsafe trait Format {
 /// for free.
 /// 
 /// # Safety
-/// Inherits safety concerns from [`Format`]
+/// 
+/// Must maintain safety invariants from [`Format`]
 pub unsafe trait SubsetOf<Super>: Format
 where
     Super: Format,
@@ -164,7 +166,7 @@ where
 /// representing exactly the same invariants.
 /// 
 /// # Safety
-/// Inherits safety constraints from [`Format`]
+/// Must maintain safety constraints from [`Format`]
 pub unsafe trait SliceFormat: Format + Sized {
     type Slice: ?Sized + Slice;
 }
@@ -174,7 +176,7 @@ pub unsafe trait SliceFormat: Format + Sized {
 /// 
 /// # Safety
 /// 
-/// Changing format without validation will cause unsoundness.
+/// When changing [`Format`], format invariants must be maintained. 
 pub unsafe trait CharFormat<'a>: Format {
     /// Iterator for characters and their byte indices.
     type Iter: Iterator<Item = (usize, char)>;
@@ -184,7 +186,7 @@ pub unsafe trait CharFormat<'a>: Format {
     /// 
     /// # Safety 
     /// 
-    /// It assumes the buffer is *already validated* for `Format`.
+    /// Must be passed a buffer that is valid for [`Format`].
     unsafe fn char_indices(buf: &'a [u8]) -> Self::Iter;
 
     /// Encode the character as bytes and pass them to a continuation.
@@ -199,7 +201,8 @@ pub unsafe trait CharFormat<'a>: Format {
 /// 
 /// # Safety
 /// 
-/// It manipulates raw data and may transmute a non-UTF [`&[u8]`] into [`str`]
+/// Types that implement [`Slice`] must maintain their format safety. 
+// TODO this trait looks like a safe trait it doesn't maintain any invariants
 pub unsafe trait Slice {
     /// Access the raw bytes of the slice.
     fn as_bytes(&self) -> &[u8];
@@ -207,13 +210,15 @@ pub unsafe trait Slice {
     /// Convert a byte slice to this kind of slice.
     ///
     /// # Safety
-    /// It assumes the buffer is *already validated* for `Format`.
+    /// 
+    /// Must be passed a buffer that is valid for [`Format`]
     unsafe fn from_bytes(x: &[u8]) -> &Self;
 
     /// Convert a byte slice to this kind of slice.
     ///
     /// # Safety
-    /// It assumes the buffer is *already validated* for `Format`.
+    /// 
+    /// Must be passed a buffer that is valid for [`Format`]
     unsafe fn from_mut_bytes(x: &mut [u8]) -> &mut Self;
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -64,7 +64,7 @@ pub mod imp {
         inner: iter::Enumerate<slice::Iter<'a, u8>>,
     }
 
-    impl<'a> Iterator for SingleByteCharIndices<'a> {
+    impl Iterator for SingleByteCharIndices<'_> {
         type Item = (usize, char);
 
         #[inline]
@@ -430,7 +430,7 @@ unsafe impl Format for WTF8 {
 
     #[inline]
     unsafe fn fixup(lhs: &[u8], rhs: &[u8]) -> imp::Fixup {
-        const ERR: &'static str = "WTF8: internal error";
+        const ERR: &str = "WTF8: internal error";
 
         if lhs.len() >= 3 && rhs.len() >= 3 {
             if let (

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -89,6 +89,9 @@ pub mod imp {
 ///
 /// The type implementing this trait is usually not instantiated.
 /// It's used with a phantom type parameter of `Tendril`.
+/// 
+/// # Safety
+/// Wrong casting of bytes to str may cause undefined behavior.
 pub unsafe trait Format {
     /// Check whether the buffer is valid for this format.
     fn validate(buf: &[u8]) -> bool;
@@ -123,6 +126,8 @@ pub unsafe trait Format {
     ///
     /// The default is to do nothing.
     ///
+    /// # Safety
+    /// 
     /// The function is `unsafe` because it may assume the input
     /// buffers are already valid for the format. Also, no
     /// bounds-checking is performed on the return value!
@@ -136,6 +141,9 @@ pub unsafe trait Format {
 ///
 /// The subset format can be converted to the superset format
 /// for free.
+/// 
+/// # Safety
+/// Inherits safety concerns from [`Format`]
 pub unsafe trait SubsetOf<Super>: Format
 where
     Super: Format,
@@ -154,20 +162,29 @@ where
 
 /// Indicates a format which corresponds to a Rust slice type,
 /// representing exactly the same invariants.
+/// 
+/// # Safety
+/// Inherits safety constraints from [`Format`]
 pub unsafe trait SliceFormat: Format + Sized {
     type Slice: ?Sized + Slice;
 }
 
 /// Indicates a format which contains characters from Unicode
 /// (all of it, or some proper subset).
+/// 
+/// # Safety
+/// 
+/// Changing format without validation will cause unsoundness.
 pub unsafe trait CharFormat<'a>: Format {
     /// Iterator for characters and their byte indices.
     type Iter: Iterator<Item = (usize, char)>;
 
     /// Iterate over the characters of the string and their byte
     /// indices.
-    ///
-    /// You may assume the buffer is *already validated* for `Format`.
+    /// 
+    /// # Safety 
+    /// 
+    /// It assumes the buffer is *already validated* for `Format`.
     unsafe fn char_indices(buf: &'a [u8]) -> Self::Iter;
 
     /// Encode the character as bytes and pass them to a continuation.
@@ -178,21 +195,25 @@ pub unsafe trait CharFormat<'a>: Format {
         F: FnOnce(&[u8]);
 }
 
-/// Indicates a Rust slice type that is represented in memory as bytes.
+/// Indicates a Rust slice type represented in memory as bytes.
+/// 
+/// # Safety
+/// 
+/// It manipulates raw data and may transmute a non-UTF [`&[u8]`] into [`str`]
 pub unsafe trait Slice {
     /// Access the raw bytes of the slice.
     fn as_bytes(&self) -> &[u8];
 
     /// Convert a byte slice to this kind of slice.
     ///
-    /// You may assume the buffer is *already validated*
-    /// for `Format`.
+    /// # Safety
+    /// It assumes the buffer is *already validated* for `Format`.
     unsafe fn from_bytes(x: &[u8]) -> &Self;
 
     /// Convert a byte slice to this kind of slice.
     ///
-    /// You may assume the buffer is *already validated*
-    /// for `Format`.
+    /// # Safety
+    /// It assumes the buffer is *already validated* for `Format`.
     unsafe fn from_mut_bytes(x: &mut [u8]) -> &mut Self;
 }
 
@@ -293,30 +314,29 @@ unsafe impl Format for UTF8 {
 
     #[inline]
     fn validate_prefix(buf: &[u8]) -> bool {
-        if buf.len() == 0 {
+        if buf.is_empty(){
             return true;
         }
-        match futf::classify(buf, buf.len() - 1) {
+        matches!(futf::classify(buf, buf.len() - 1),
             Some(Codepoint {
                 meaning: Meaning::Whole(_),
                 ..
-            }) => true,
-            _ => false,
-        }
+            })
+        )
     }
 
     #[inline]
     fn validate_suffix(buf: &[u8]) -> bool {
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return true;
         }
-        match futf::classify(buf, 0) {
+        matches!(
+            futf::classify(buf, 0),
             Some(Codepoint {
                 meaning: Meaning::Whole(_),
                 ..
-            }) => true,
-            _ => false,
-        }
+            })
+        )
     }
 
     #[inline]
@@ -374,10 +394,9 @@ pub struct WTF8;
 
 #[inline]
 fn wtf8_meaningful(m: Meaning) -> bool {
-    match m {
-        Meaning::Whole(_) | Meaning::LeadSurrogate(_) | Meaning::TrailSurrogate(_) => true,
-        _ => false,
-    }
+    matches!(m,  
+        Meaning::Whole(_) | Meaning::LeadSurrogate(_) | Meaning::TrailSurrogate(_)
+    )
 }
 
 unsafe impl Format for WTF8 {
@@ -403,7 +422,7 @@ unsafe impl Format for WTF8 {
 
     #[inline]
     fn validate_prefix(buf: &[u8]) -> bool {
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return true;
         }
         match futf::classify(buf, buf.len() - 1) {
@@ -414,7 +433,7 @@ unsafe impl Format for WTF8 {
 
     #[inline]
     fn validate_suffix(buf: &[u8]) -> bool {
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return true;
         }
         match futf::classify(buf, 0) {

--- a/src/futf.rs
+++ b/src/futf.rs
@@ -134,7 +134,7 @@ unsafe fn decode(buf: &[u8]) -> Option<Meaning> {
 }
 
 #[inline(always)]
-unsafe fn unsafe_slice<'a>(buf: &'a [u8], start: usize, new_len: usize) -> &'a [u8] {
+unsafe fn unsafe_slice(buf: &[u8], start: usize, new_len: usize) -> &[u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
     slice::from_raw_parts(buf.as_ptr().offset(start as isize), new_len)
@@ -152,7 +152,7 @@ macro_rules! otry {
 /// Returns `None` if `idx` is out of range, or if `buf` contains invalid UTF-8
 /// in the vicinity of `idx`.
 #[inline]
-pub fn classify<'a>(buf: &'a [u8], idx: usize) -> Option<Codepoint<'a>> {
+pub fn classify(buf: &[u8], idx: usize) -> Option<Codepoint> {
     if idx >= buf.len() {
         return None;
     }

--- a/src/futf.rs
+++ b/src/futf.rs
@@ -75,9 +75,9 @@ impl Byte {
     fn classify(x: u8) -> Option<Byte> {
         match x & 0xC0 {
             0xC0 => match x {
-                x if x & 0b11111_000 == 0b11110_000 => Some(Byte::Start(4)),
+                x if x & 0b1111_1000 == 0b1111_0000 => Some(Byte::Start(4)),
                 x if x & 0b1111_0000 == 0b1110_0000 => Some(Byte::Start(3)),
-                x if x & 0b111_00000 == 0b110_00000 => Some(Byte::Start(2)),
+                x if x & 0b1110_0000 == 0b1100_0000 => Some(Byte::Start(2)),
                 _ => None,
             },
             0x80 => Some(Byte::Cont),
@@ -137,7 +137,7 @@ unsafe fn decode(buf: &[u8]) -> Option<Meaning> {
 unsafe fn unsafe_slice(buf: &[u8], start: usize, new_len: usize) -> &[u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
-    slice::from_raw_parts(buf.as_ptr().offset(start as isize), new_len)
+    slice::from_raw_parts(buf.as_ptr().add(start), new_len)
 }
 
 macro_rules! otry {
@@ -174,9 +174,9 @@ pub fn classify(buf: &[u8], idx: usize) -> Option<Codepoint> {
                     }
                     let meaning = otry!(decode(bytes));
                     Some(Codepoint {
-                        bytes: bytes,
+                        bytes,
                         rewind: 0,
-                        meaning: meaning,
+                        meaning,
                     })
                 } else {
                     Some(Codepoint {
@@ -207,16 +207,14 @@ pub fn classify(buf: &[u8], idx: usize) -> Option<Codepoint> {
                             let avail = buf.len() - start;
                             if avail >= n {
                                 let bytes = unsafe_slice(buf, start, n);
-                                if checked < n {
-                                    if !all_cont(unsafe_slice(bytes, checked, n - checked)) {
-                                        return None;
-                                    }
+                                if checked < n  && !all_cont(unsafe_slice(bytes, checked, n - checked)) {
+                                    return None;
                                 }
                                 let meaning = otry!(decode(bytes));
                                 return Some(Codepoint {
-                                    bytes: bytes,
+                                    bytes,
                                     rewind: idx - start,
-                                    meaning: meaning,
+                                    meaning,
                                 });
                             } else {
                                 return Some(Codepoint {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,4 +34,4 @@ mod tendril;
 mod utf8_decode;
 mod util;
 
-static OFLOW: &'static str = "tendril: overflow in buffer arithmetic";
+static OFLOW: &str = "tendril: overflow in buffer arithmetic";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,7 @@ extern crate utf8;
 
 pub use fmt::Format;
 pub use stream::TendrilSink;
-pub use tendril::{Atomic, Atomicity, NonAtomic, SendTendril};
-pub use tendril::{ByteTendril, ReadExt, SliceExt, StrTendril, SubtendrilError, Tendril};
+pub use crate::tendril::{Atomic, Atomicity, NonAtomic, SendTendril, ByteTendril, ReadExt, SliceExt, StrTendril, SubtendrilError, Tendril};
 pub use utf8_decode::IncompleteUtf8;
 
 pub mod fmt;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,8 +6,8 @@
 
 //! Streams of tendrils.
 
-use fmt;
-use tendril::{Atomicity, NonAtomic, Tendril};
+use crate::fmt;
+use crate::{Atomicity, NonAtomic, Tendril};
 
 use std::borrow::Cow;
 use std::fs::File;
@@ -465,14 +465,14 @@ fn decode_to_sink<Sink, A>(
 #[cfg(test)]
 mod test {
     use super::{TendrilSink, Utf8LossyDecoder};
-    use fmt;
+    use crate::fmt;
     use std::borrow::Cow;
-    use tendril::{Atomicity, NonAtomic, Tendril};
+    use crate::tendril::{Atomicity, NonAtomic, Tendril};
 
     #[cfg(any(feature = "encoding", feature = "encoding_rs"))]
     use super::LossyDecoder;
     #[cfg(any(feature = "encoding", feature = "encoding_rs"))]
-    use tendril::SliceExt;
+    use crate::tendril::SliceExt;
 
     #[cfg(feature = "encoding")]
     use encoding::all as enc;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -139,7 +139,7 @@ where
     #[inline]
     pub fn new(inner_sink: Sink) -> Self {
         Utf8LossyDecoder {
-            inner_sink: inner_sink,
+            inner_sink,
             incomplete: None,
             marker: PhantomData,
         }
@@ -605,7 +605,7 @@ mod test {
     #[cfg(any(feature = "encoding", feature = "encoding_rs"))]
     pub type Tests = &'static [(&'static [&'static [u8]], &'static str, usize)];
 
-    #[cfg(any(feature = "encoding"))]
+    #[cfg(feature = "encoding")]
     const ASCII: Tests = &[
         (&[], "", 0),
         (&[b""], "", 0),

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -1144,7 +1144,7 @@ where
     }
 
     #[inline]
-    fn as_byte_slice<'a>(&'a self) -> &'a [u8] {
+    fn as_byte_slice(&self) -> &[u8] {
         unsafe {
             match self.ptr.get().get() {
                 EMPTY_TAG => &[],
@@ -1163,7 +1163,7 @@ where
     // There's no need to worry about locking on an atomic Tendril, because it makes it unique as
     // soon as you do that.
     #[inline]
-    fn as_mut_byte_slice<'a>(&'a mut self) -> &'a mut [u8] {
+    fn as_mut_byte_slice(&mut self) -> &mut [u8] {
         unsafe {
             match self.ptr.get().get() {
                 EMPTY_TAG => &mut [],
@@ -1283,7 +1283,7 @@ where
 {
     /// Remove and return the first character, if any.
     #[inline]
-    pub fn pop_front_char<'a>(&'a mut self) -> Option<char> {
+    pub fn pop_front_char(&mut self) -> Option<char> {
         unsafe {
             let next_char; // first char in iterator
             let mut skip = 0; // number of bytes to skip, or 0 to clear
@@ -1323,7 +1323,7 @@ where
     ///
     /// Returns `None` on an empty string.
     #[inline]
-    pub fn pop_front_char_run<'a, C, R>(&'a mut self, mut classify: C) -> Option<(Tendril<F, A>, R)>
+    pub fn pop_front_char_run<C, R>(&mut self, mut classify: C) -> Option<(Tendril<F, A>, R)>
     where
         C: FnMut(char) -> R,
         R: PartialEq,
@@ -1603,7 +1603,7 @@ macro_rules! format_tendril {
     ($($arg:tt)*) => ($crate::StrTendril::format(format_args!($($arg)*)))
 }
 
-impl<'a, F, A> From<&'a F::Slice> for Tendril<F, A>
+impl<F, A> From<&F::Slice> for Tendril<F, A>
 where
     F: fmt::SliceFormat,
     A: Atomicity,

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -24,7 +24,7 @@ use crate::buf32::{self, Buf32};
 use crate::fmt::imp::Fixup;
 use crate::fmt::{self, Slice};
 use crate::util::{copy_and_advance, copy_lifetime, copy_lifetime_mut, unsafe_slice, unsafe_slice_mut};
-use crate::{OFLOW};
+use crate::{Format, OFLOW};
 
 const MAX_INLINE_LEN: usize = 8;
 const MAX_INLINE_TAG: usize = 0xF;
@@ -51,7 +51,7 @@ fn inline_tag(len: u32) -> NonZeroUsize {
 /// 
 /// # Safety
 /// 
-/// Implementing this trait is unsafe due to different atomic guarantees.
+/// When implementing this trait must maintain atomicity invariants.
 pub unsafe trait Atomicity: 'static {
     #[doc(hidden)]
     fn new() -> Self;
@@ -895,7 +895,7 @@ where
     /// 
     /// # Safety
     /// 
-    /// - Tendril should be in target format, otherwise this fails.
+    ///  [`Tendril`] must be safe to transmute into [`Other`]
     #[inline(always)]
     pub unsafe fn reinterpret_view_without_validating<Other>(&self) -> &Tendril<Other, A>
     where
@@ -908,7 +908,7 @@ where
     /// 
     /// # Safety
     /// 
-    /// - Tendril should be in target format, otherwise it's unsound
+    /// [`Tendril`] must be safe to transmute into [`Other`]
     #[inline(always)]
     pub unsafe fn reinterpret_without_validating<Other>(self) -> Tendril<Other, A>
     where
@@ -921,8 +921,8 @@ where
     /// 
     /// # Safety
     /// 
-    /// - Slice is below 4GiB
-    /// - Its encoding matches Tendril's
+    /// - Slice must be below 4GiB
+    /// - Its encoding must matches [`Tendril`]'s
     #[inline]
     pub unsafe fn from_byte_slice_without_validating(x: &[u8]) -> Tendril<F, A> {
         assert!(x.len() <= buf32::MAX_LEN);
@@ -933,11 +933,11 @@ where
         }
     }
 
-    /// Push some bytes onto the end of the `Tendril`, without validating.
+    /// Push some bytes onto the end of the [`Tendril`], without validating.
     /// 
     /// # Safety
     /// 
-    /// 
+    /// Slice must be safe to append to this [`Tendril`]
     #[inline]
     pub unsafe fn push_bytes_without_validating(&mut self, buf: &[u8]) {
         assert!(buf.len() <= buf32::MAX_LEN);
@@ -991,10 +991,11 @@ where
         }
     }
 
-    /// Slice this `Tendril` as a new `Tendril`.
+    /// Slice this [`Tendril`] as a new [`Tendril`]
     ///
     /// # Safety 
-    /// Must check validity or bounds!
+    /// 
+    /// [`Tendril`] bounds must be valid, such that [`Format`] invariants are kept.
     #[inline]
     pub unsafe fn unsafe_subtendril(&self, offset: u32, length: u32) -> Tendril<F, A> {
         if length <= MAX_INLINE_LEN as u32 {
@@ -1517,7 +1518,7 @@ where
     /// 
     /// # Safety
     /// 
-    /// When creating uninitialized bits
+    /// When creating uninitialized bits, must ensure enough capacity is available.
     #[inline]
     pub unsafe fn push_uninitialized(&mut self, n: u32) {
         let new_len = self.len32().checked_add(n).expect(OFLOW);

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::atomic::{self, AtomicUsize};
-use std::{hash, io, mem, ptr, str, u32};
+use std::{hash, io, mem, ptr, str};
 
 #[cfg(feature = "encoding")]
 use encoding::{self, DecoderTrap, EncoderTrap, EncodingRef};
@@ -24,7 +24,7 @@ use crate::buf32::{self, Buf32};
 use crate::fmt::imp::Fixup;
 use crate::fmt::{self, Slice};
 use crate::util::{copy_and_advance, copy_lifetime, copy_lifetime_mut, unsafe_slice, unsafe_slice_mut};
-use crate::OFLOW;
+use crate::{OFLOW};
 
 const MAX_INLINE_LEN: usize = 8;
 const MAX_INLINE_TAG: usize = 0xF;
@@ -48,6 +48,10 @@ fn inline_tag(len: u32) -> NonZeroUsize {
 ///
 /// The layout of this trait is also mandated to be that of a `usize`,
 /// for it is used for reference counting.
+/// 
+/// # Safety
+/// 
+/// Implementing this trait is unsafe due to different atomic guarantees.
 pub unsafe trait Atomicity: 'static {
     #[doc(hidden)]
     fn new() -> Self;
@@ -464,11 +468,6 @@ where
     fn eq(&self, other: &Self) -> bool {
         self.as_byte_slice() == other.as_byte_slice()
     }
-
-    #[inline]
-    fn ne(&self, other: &Self) -> bool {
-        self.as_byte_slice() != other.as_byte_slice()
-    }
 }
 
 impl<F, A> Eq for Tendril<F, A>
@@ -668,7 +667,7 @@ where
         SendTendril {
             // This changes the header.refcount from A to NonAtomic, but that's
             // OK because we have defined the format of A as a usize.
-            tendril: unsafe { mem::transmute(self) },
+            tendril: unsafe { mem::transmute::<Tendril<F, A>, Tendril<F>>(self) },
         }
     }
 
@@ -699,7 +698,7 @@ where
         Sub: fmt::SubsetOf<F>,
     {
         match Sub::revalidate_subset(self.as_byte_slice()) {
-            true => Ok(unsafe { mem::transmute(self) }),
+            true => Ok(unsafe { mem::transmute::<&Tendril<F, A>, &Tendril<Sub, A>>(self) }),
             false => Err(()),
         }
     }
@@ -711,7 +710,7 @@ where
         Sub: fmt::SubsetOf<F>,
     {
         match Sub::revalidate_subset(self.as_byte_slice()) {
-            true => Ok(unsafe { mem::transmute(self) }),
+            true => Ok(unsafe { mem::transmute::<Tendril<F, A>, Tendril<Sub, A>>(self) }),
             false => Err(self),
         }
     }
@@ -724,7 +723,7 @@ where
         Other: fmt::Format,
     {
         match Other::validate(self.as_byte_slice()) {
-            true => Ok(unsafe { mem::transmute(self) }),
+            true => Ok(unsafe { mem::transmute::<&Tendril<F, A>, &Tendril<Other, A>>(self) }),
             false => Err(()),
         }
     }
@@ -741,7 +740,7 @@ where
         Other: fmt::Format,
     {
         match Other::validate(self.as_byte_slice()) {
-            true => Ok(unsafe { mem::transmute(self) }),
+            true => Ok(unsafe { mem::transmute::<Tendril<F, A>, Tendril<Other, A>>(self) }),
             false => Err(self),
         }
     }
@@ -893,6 +892,10 @@ where
     }
 
     /// View as another format, without validating.
+    /// 
+    /// # Safety
+    /// 
+    /// - Tendril should be in target format, otherwise this fails.
     #[inline(always)]
     pub unsafe fn reinterpret_view_without_validating<Other>(&self) -> &Tendril<Other, A>
     where
@@ -902,6 +905,10 @@ where
     }
 
     /// Convert into another format, without validating.
+    /// 
+    /// # Safety
+    /// 
+    /// - Tendril should be in target format, otherwise it's unsound
     #[inline(always)]
     pub unsafe fn reinterpret_without_validating<Other>(self) -> Tendril<Other, A>
     where
@@ -911,6 +918,11 @@ where
     }
 
     /// Build a `Tendril` by copying a byte slice, without validating.
+    /// 
+    /// # Safety
+    /// 
+    /// - Slice is below 4GiB
+    /// - Its encoding matches Tendril's
     #[inline]
     pub unsafe fn from_byte_slice_without_validating(x: &[u8]) -> Tendril<F, A> {
         assert!(x.len() <= buf32::MAX_LEN);
@@ -922,6 +934,10 @@ where
     }
 
     /// Push some bytes onto the end of the `Tendril`, without validating.
+    /// 
+    /// # Safety
+    /// 
+    /// 
     #[inline]
     pub unsafe fn push_bytes_without_validating(&mut self, buf: &[u8]) {
         assert!(buf.len() <= buf32::MAX_LEN);
@@ -962,7 +978,7 @@ where
             let (owned, _, _) = self.assume_buf();
             let mut dest = owned
                 .data_ptr()
-                .offset((owned.len as usize - drop_left) as isize);
+                .add(owned.len as usize - drop_left);
             copy_and_advance(
                 &mut dest,
                 unsafe_slice(&insert_bytes, 0, insert_len as usize),
@@ -977,7 +993,8 @@ where
 
     /// Slice this `Tendril` as a new `Tendril`.
     ///
-    /// Does not check validity or bounds!
+    /// # Safety 
+    /// Must check validity or bounds!
     #[inline]
     pub unsafe fn unsafe_subtendril(&self, offset: u32, length: u32) -> Tendril<F, A> {
         if length <= MAX_INLINE_LEN as u32 {
@@ -996,7 +1013,8 @@ where
 
     /// Drop `n` bytes from the front.
     ///
-    /// Does not check validity or bounds!
+    /// # Safety
+    /// Must check validity or bounds!
     #[inline]
     pub unsafe fn unsafe_pop_front(&mut self, n: u32) {
         let new_len = self.len32() - n;
@@ -1016,7 +1034,9 @@ where
 
     /// Drop `n` bytes from the back.
     ///
-    /// Does not check validity or bounds!
+    /// # Safety
+    /// 
+    /// Validity and bounds must be checked beforehand.
     #[inline]
     pub unsafe fn unsafe_pop_back(&mut self, n: u32) {
         let new_len = self.len32() - n;
@@ -1059,6 +1079,11 @@ where
         }
     }
 
+    /// Creates an owned buffer with capacity
+    /// 
+    /// # Safety
+    /// * `self.buf` must not be zero
+    /// * can't allocate more than 4GiB of total memory
     #[inline]
     unsafe fn make_owned_with_capacity(&mut self, cap: u32) {
         self.make_owned();
@@ -1072,7 +1097,7 @@ where
     unsafe fn header(&self) -> *mut Header<A> {
         (self.ptr.get().get() & !1) as *mut Header<A>
     }
-
+    
     #[inline]
     unsafe fn assume_buf(&self) -> (Buf32<Header<A>>, bool, u32) {
         let ptr = self.ptr.get().get();
@@ -1087,13 +1112,18 @@ where
             Buf32 {
                 ptr: header,
                 len: offset + self.len32(),
-                cap: cap,
+                cap,
             },
             shared,
             offset,
         )
     }
 
+    /// Create Tendril inline
+    /// 
+    /// # Safety
+    /// 
+    /// - Slice `x` must be below eight bytes
     #[inline]
     unsafe fn inline(x: &[u8]) -> Tendril<F, A> {
         let len = x.len();
@@ -1333,7 +1363,7 @@ where
             let mut chars = unsafe { F::char_indices(self.as_byte_slice()) };
             let (_, first) = unwrap_or_return!(chars.next(), None);
             class = classify(first);
-            first_mismatch = chars.find(|&(_, ch)| &classify(ch) != &class);
+            first_mismatch = chars.find(|&(_, ch)| classify(ch) != class);
         }
 
         match first_mismatch {
@@ -1484,6 +1514,10 @@ where
     /// Really, this grows the tendril without writing anything to the new area.
     /// It's only defined for byte tendrils because it's only useful if you
     /// plan to then mutate the buffer.
+    /// 
+    /// # Safety
+    /// 
+    /// When creating uninitialized bits
     #[inline]
     pub unsafe fn push_uninitialized(&mut self, n: u32) {
         let new_len = self.len32().checked_add(n).expect(OFLOW);
@@ -1631,7 +1665,7 @@ where
 {
     #[inline]
     fn as_ref(&self) -> &F::Slice {
-        &**self
+        self
     }
 }
 

--- a/src/tendril.rs
+++ b/src/tendril.rs
@@ -20,11 +20,11 @@ use std::{hash, io, mem, ptr, str, u32};
 #[cfg(feature = "encoding")]
 use encoding::{self, DecoderTrap, EncoderTrap, EncodingRef};
 
-use buf32::{self, Buf32};
-use fmt::imp::Fixup;
-use fmt::{self, Slice};
-use util::{copy_and_advance, copy_lifetime, copy_lifetime_mut, unsafe_slice, unsafe_slice_mut};
-use OFLOW;
+use crate::buf32::{self, Buf32};
+use crate::fmt::imp::Fixup;
+use crate::fmt::{self, Slice};
+use crate::util::{copy_and_advance, copy_lifetime, copy_lifetime_mut, unsafe_slice, unsafe_slice_mut};
+use crate::OFLOW;
 
 const MAX_INLINE_LEN: usize = 8;
 const MAX_INLINE_TAG: usize = 0xF;
@@ -1664,7 +1664,7 @@ mod test {
     use super::{
         Atomic, ByteTendril, Header, NonAtomic, ReadExt, SendTendril, SliceExt, StrTendril, Tendril,
     };
-    use fmt;
+    use crate::fmt;
     use std::iter;
     use std::thread;
 

--- a/src/utf8_decode.rs
+++ b/src/utf8_decode.rs
@@ -6,7 +6,6 @@
 
 use crate::fmt;
 use crate::tendril::{Atomicity, Tendril};
-use utf8;
 
 pub struct IncompleteUtf8(utf8::Incomplete);
 
@@ -82,16 +81,15 @@ impl IncompleteUtf8 {
         A: Atomicity,
         F: FnMut(Tendril<fmt::UTF8, A>),
     {
-        let resume_at;
-        match self.0.try_complete(&input) {
+        let resume_at= match self.0.try_complete(&input) {
             None => return Err(()),
             Some((result, rest)) => {
                 push_utf8(Tendril::from_slice(
                     result.unwrap_or(utf8::REPLACEMENT_CHARACTER),
                 ));
-                resume_at = input.len() - rest.len();
+                input.len() - rest.len()
             }
-        }
+        };
         input.pop_front(resume_at as u32);
         Ok(input)
     }

--- a/src/utf8_decode.rs
+++ b/src/utf8_decode.rs
@@ -4,8 +4,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use fmt;
-use tendril::{Atomicity, Tendril};
+use crate::fmt;
+use crate::tendril::{Atomicity, Tendril};
 use utf8;
 
 pub struct IncompleteUtf8(utf8::Incomplete);

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ use std::{ptr, slice};
 pub unsafe fn unsafe_slice(buf: &[u8], start: usize, new_len: usize) -> &[u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
-    slice::from_raw_parts(buf.as_ptr().offset(start as isize), new_len)
+    slice::from_raw_parts(buf.as_ptr().add(start), new_len)
 }
 
 #[inline(always)]
@@ -22,7 +22,7 @@ pub unsafe fn unsafe_slice_mut(
 ) -> &mut [u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
-    slice::from_raw_parts_mut(buf.as_mut_ptr().offset(start as isize), new_len)
+    slice::from_raw_parts_mut(buf.as_mut_ptr().add(start), new_len)
 }
 
 #[inline(always)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,18 +8,18 @@ use std::mem;
 use std::{ptr, slice};
 
 #[inline(always)]
-pub unsafe fn unsafe_slice<'a>(buf: &'a [u8], start: usize, new_len: usize) -> &'a [u8] {
+pub unsafe fn unsafe_slice(buf: &[u8], start: usize, new_len: usize) -> &[u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
     slice::from_raw_parts(buf.as_ptr().offset(start as isize), new_len)
 }
 
 #[inline(always)]
-pub unsafe fn unsafe_slice_mut<'a>(
-    buf: &'a mut [u8],
+pub unsafe fn unsafe_slice_mut(
+    buf: &mut [u8],
     start: usize,
     new_len: usize,
-) -> &'a mut [u8] {
+) -> &mut [u8] {
     debug_assert!(start <= buf.len());
     debug_assert!(new_len <= (buf.len() - start));
     slice::from_raw_parts_mut(buf.as_mut_ptr().offset(start as isize), new_len)


### PR DESCRIPTION
- use `crate::` syntax
- set edition to 2018
- add `transmute` type annotations
- add very rough `# Safety` docs
- replace `ptr.offset(usize)` with `ptr.add(usize)`
- replace `buf.len() == 0` with `buf.is_empty()`
- replaced simple `match` with `matches!` macro
- moved binary separators to align on four bits (i.e `111_0000` -> `1110_0000`)
- simplify constructor calls by replacing 
``` 
Codepoint {
       bytes: bytes,
       ..
}
``` 
into 
```
Codepoint {
   bytes,
   ..
}
```